### PR TITLE
Article path calculation optimization

### DIFF
--- a/packages/pure/components/pages/ArticleBottom.astro
+++ b/packages/pure/components/pages/ArticleBottom.astro
@@ -11,7 +11,7 @@ type Props = {
 
 // Get the requested entry
 const { id, collections, class: className } = Astro.props
-const path = Astro.url.pathname.split('/').slice(0, -1).join('/')
+const path = Astro.url.pathname.split('/').slice(0, 2).join('/')
 
 // Get the next and prev entries (modulo to wrap index)
 const index = collections.findIndex((x) => x.id === id)


### PR DESCRIPTION
When obtaining the current path, the algorithm used is to intercept the content after the last `/` This logic may cause bugs

eg: If the current article address contains multi-level directories, for example: www.domain.com/blog/devops/k8s-gateway-api, Using the current algorithm will cause the final calculated path value  incorrectly include the content of the secondary path **devops**, making the ​​prev/next article address invalid, resulting in 404

Considering that all article paths in the current project start with **/blog,** it is recommended to intercept the first two parts of the array to append the prev/next article `[subdirectory + article id]`, which is `/blog/[subdirectory + article id]`