### PR TITLE
对waline评论区功能的一些建议

### DIFF
--- a/packages/pure/types/integrations-config.ts
+++ b/packages/pure/types/integrations-config.ts
@@ -54,6 +54,8 @@ export const IntegrationConfigSchema = () =>
       server: z.string().optional(),
       /** The emoji to use for the Waline comment system. */
       emoji: z.array(z.string()).optional(),
+      /** Enable emoji preview box for the Waline comment system. */
+      emojiPreview: z.boolean().default(false),
       /** Additional configurations for the Waline comment system. */
       additionalConfigs: z.record(z.string(), z.any()).default({})
     })

--- a/src/components/waline/Comment.astro
+++ b/src/components/waline/Comment.astro
@@ -53,7 +53,7 @@ const { class: className } = Astro.props
         ...walineConfig.additionalConfigs
       })
 
-      this._initEmojiPreview()
+      if (walineConfig.emojiPreview) this._initEmojiPreview()
     }
 
     disconnectedCallback() {

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -167,6 +167,8 @@ export const integ: IntegrationUserConfig = {
     server: 'https://astro-theme-pure-waline.arthals.ink/',
     // Refer https://waline.js.org/en/guide/features/emoji.html
     emoji: ['bmoji', 'weibo'],
+    // Enable emoji preview box for the Waline comment system
+    emojiPreview: true,
     // Refer https://waline.js.org/en/reference/client/props.html
     additionalConfigs: {
       // search: false,


### PR DESCRIPTION
## 解决 在对已存在的评论进行评论时，表情框及GIF搜索框无法完整显示 的问题

fix(waline): change overflow property from hidden to visible

在编写表情包预览功能时发现的小bug？(maybe...不知道为什么设置成 `hidden` (＠_＠;))

- 修复评论项因将溢出设置为可见而不是隐藏而被不必要地裁剪

**详细图片：**
<img width="1260" height="876" alt="8b7b9218b84dc1892c3fc7c50ac3761a" src="https://github.com/user-attachments/assets/d788aed5-8b22-462a-b125-42c9484a19c0" />
<img width="1266" height="861" alt="ba363f3acd166e186709d4067a5f9371" src="https://github.com/user-attachments/assets/d9583c98-9b0b-4722-b528-1b09e32be7c9" />

## 初步实现表情预览功能

feat(comment): add emoji preview functionality for better UX

具体包括：
- 预览框的创建和定位逻辑
- 鼠标交互的事件处理
- 组件断开时的清理
- 预览框的样式

### 为什么提出此改动？

>Waline 默认把表情图片控制在 28px～32px 左右的小图标尺寸，因为如果每个评论中都能发送 200px 的大表情，评论区排版会变得混乱、文字行距高度会被撑开。多条评论就会撑到页面布局，甚至影响移动端阅读体验。所以 Waline 默认强制缩小，以保持评论区的干净、整齐、可读性。

而很多表情包（特别一些**GIF**动图、**LINE**风格图片）里面有文字或者微小的细节，被waline缩略后图片根本看不清。

此 **PR** 则弥补了无法预览表情详情的缺陷

改动后演示：

https://github.com/user-attachments/assets/9644780f-be63-40d2-ba2c-0d35bb6c7a72


### 仍有不足

- [ ] 样式无法随日夜间模式切换
- [ ] 移动端仍无法预览表情