### PR TITLE
feat(ui): improve Tabs layout on mobile and pc

### DIFF
--- a/packages/pure/components/user/Tabs.astro
+++ b/packages/pure/components/user/Tabs.astro
@@ -81,6 +81,7 @@ if (isSynced) {
             <li role='presentation' class='tab'>
               <a
                 role='tab'
+                draggable="false"
                 href={'#' + panelId}
                 id={tabId}
                 aria-selected={idx === 0 ? 'true' : 'false'}
@@ -105,11 +106,6 @@ if (isSynced) {
 
   .tablist-wrapper {
     overflow-x: auto;
-    scrollbar-width: none;
-    user-select: none;
-  }
-  .tablist-wrapper::-webkit-scrollbar {
-    display: none;
   }
 
   [role='tablist'] {
@@ -169,64 +165,10 @@ if (isSynced) {
         StarlightTabs.#syncedTabs.set(this.#syncKey, syncedTabs)
       }
 
-      const slider = this.querySelector<HTMLElement>('.tablist-wrapper');
-      
-      let isDragging = false;
-      let startX = 0;
-      let scrollLeft = 0;
-      let velX = 0; 
-      let rafId: number | null = null; 
-
-      if (slider) {
-        const momentumLoop = () => {
-          if (Math.abs(velX) > 0.5) {
-            slider.scrollLeft += velX;
-            velX *= 0.95;
-            rafId = requestAnimationFrame(momentumLoop);
-          } else {
-            rafId = null; 
-          }
-        };
-
-        const onMouseMove = (e: MouseEvent) => {
-          e.preventDefault();
-          const x = e.pageX - slider.offsetLeft;
-          const walk = x - startX;
-          const newScrollLeft = scrollLeft - walk;
-          velX = newScrollLeft - slider.scrollLeft;
-          if (Math.abs(walk) > 5) isDragging = true;
-          slider.scrollLeft = newScrollLeft;
-        };
-
-        const onMouseUp = () => {
-          window.removeEventListener('mousemove', onMouseMove);
-          window.removeEventListener('mouseup', onMouseUp);
-          setTimeout(() => { isDragging = false; }, 0);
-          momentumLoop();
-        };
-
-        slider.addEventListener('dragstart', (e) => e.preventDefault());
-
-        slider.addEventListener('mousedown', (e) => {
-          if (rafId !== null) {
-            cancelAnimationFrame(rafId);
-            rafId = null;
-          }
-          isDragging = false;
-          startX = e.pageX - slider.offsetLeft;
-          scrollLeft = slider.scrollLeft;
-          velX = 0; 
-
-          window.addEventListener('mousemove', onMouseMove);
-          window.addEventListener('mouseup', onMouseUp);
-        });
-      }
-
       this.tabs.forEach((tab, i) => {
         // Handle clicks for mouse users
         tab.addEventListener('click', (e) => {
           e.preventDefault()
-          if (isDragging) return;
           const currentTab = tablist.querySelector('[aria-selected="true"]')
           if (e.currentTarget !== currentTab) {
             this.switchTab(e.currentTarget as HTMLAnchorElement, i)


### PR DESCRIPTION
此PR对Tabs组件进行了修改：
1.移动端布局：修复了长标题换行导致Tab高度不一致和底部指示条错位的问题。
2.PC端：在隐藏滚动条的情况下，实现了和移动端相同的滑动功能。

具体内容：
1.强制单行：给Tab添加了white-space: nowrap ，防止标题文字换行，确保所有 Tab 高度一致。
2.隐藏滚动条：兼容Firefox(scrollbar-width: none)和WebKit(::-webkit-scrollbar)。
3.物理惯性：基于requestAnimationFrame实现惯性滚动，并支持全屏拖拽响应(window 监听)。
4.冲突处理：通过5px阈值判定和dragstart拦截，解决点击事件冲突和原生拖拽鬼影。

效果对比：
前：移动端标题错乱，pc端标题错乱且不可滑动
<img width="745" height="662" alt="before" src="https://github.com/user-attachments/assets/4ed2a0fa-afa9-46e6-9c7f-de0fc05b4c87" />

后：pc端和移动端都实现标题统一且可滑动
<img width="743" height="571" alt="after" src="https://github.com/user-attachments/assets/f247f922-2dc9-49e7-84fe-847d7234cb54" />


