### PR TITLE
修正RSS Feed在FreshRSS中的显示

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -57,6 +57,23 @@ const GET = async (context: AstroGlobal) => {
   const allPostsByDate = sortMDByDate(await getBlogCollection()) as CollectionEntry<'blog'>[]
   const siteUrl = context.site ?? new URL(import.meta.env.SITE)
 
+  // --- 新增：处理头图逻辑 ---
+  let heroImageUrl = '';
+  if (post.data.heroImage) {
+  // 如果是字符串直接用，如果是 Astro 优化后的对象则取 .src
+  heroImageUrl = typeof post.data.heroImage.src === 'string' 
+    ? post.data.heroImage.src 
+    : post.data.heroImage.src.src;
+  // 如果是相对路径，拼上完整的 site 域名
+    if (heroImageUrl.startsWith('/')) {
+      heroImageUrl = `${siteUrl.origin}${heroImageUrl}`;
+    }
+  }
+  // --- 只有当图片存在时才生成相关的 XML 标签 ---
+  const imageTags = heroImageUrl
+    ? `<h:img src="${heroImageUrl}" /><enclosure url="${heroImageUrl}" length="0" type="image/jpeg" />` 
+    : '';
+  
   return rss({
     // Basic configs
     trailingSlash: false,
@@ -71,8 +88,7 @@ const GET = async (context: AstroGlobal) => {
       allPostsByDate.map(async (post) => ({
         pubDate: post.data.publishDate,
         link: `/blog/${post.id}`,
-        customData: `<h:img src="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />
-          <enclosure url="${typeof post.data.heroImage?.src === 'string' ? post.data.heroImage?.src : post.data.heroImage?.src.src}" />`,
+        customData: imageTags,
         content: await renderContent(post, siteUrl),
         ...post.data
       }))


### PR DESCRIPTION
在FreshRSS等self-hosted rss中，如果设置了heroImage，那在通过feed获取的博文结尾heroImage会再出现一次
<img width="2834" height="1511" alt="1" src="https://github.com/user-attachments/assets/6cfd725b-f4b8-4dac-860a-58e6ad032e8c" />
如果没有设置，则会出现`https://YOUR-DOMAIN/undefined`
<img width="2834" height="1534" alt="2" src="https://github.com/user-attachments/assets/bd124e51-0262-44eb-83ee-daeb4450854e" />
而如果是在RSS Reader中直接输入RSS订阅源url，则不会出现这种事。可能是因为FreshRSS强制提取enclosure 标签以及其容错处理不足。通过FreshRSS的CSS选择器选择性设置img,p,h1,h2,h3,h4,h5,h6后无济于事
修改后，无论是通过FreshRSS获取rss feed还是在RSS Reader中直接输入RSS订阅源url，都能准确显示