### PR TITLE
feat(ui): optimize URL display with Chinese decoding and overflow control

### DIFF
--- a/packages/pure/components/pages/Copyright.astro
+++ b/packages/pure/components/pages/Copyright.astro
@@ -3,7 +3,7 @@ import type { CollectionKey, InferEntrySchema } from 'astro:content'
 
 import config from 'virtual:config'
 
-import { cn, getFormattedDate } from '../../utils'
+import { cn, getFormattedDate, getDisplayUrl } from '../../utils'
 import { QRCode } from '../advanced'
 import { Icon } from '../user'
 
@@ -43,7 +43,7 @@ const shares = {
   {/* title & link */}
   <div class='flex flex-col'>
     <div class='font-medium text-foreground'>{title}</div>
-    <div class='text-sm'>{Astro.url}</div>
+    <div class='text-sm w-3/4 break-all' set:html={getDisplayUrl(Astro.url.href)}></div>
   </div>
 
   {/* common info */}

--- a/packages/pure/utils/index.ts
+++ b/packages/pure/utils/index.ts
@@ -4,6 +4,9 @@ export { default as mdastToString } from './mdast-util-to-string'
 export { default as getReadingTime } from './reading-time'
 export { default as isAbsoluteUrl } from './is-absolute-url'
 
+// URL utilities
+export { decodeUrl, formatUrlForDisplay, getDisplayUrl } from './url'
+
 // Class merge
 export { cn } from './class-merge'
 

--- a/packages/pure/utils/url.ts
+++ b/packages/pure/utils/url.ts
@@ -1,0 +1,35 @@
+/**
+ * 解码URL中的编码字符（如中文）
+ * @param url - 需要解码的URL字符串
+ * @returns 解码后的URL字符串
+ */
+export function decodeUrl(url: string): string {
+  try {
+    return decodeURIComponent(url)
+  } catch {
+    // 如果解码失败，返回原始URL
+    return url
+  }
+}
+
+/**
+ * 格式化URL显示，只解码不限制行数
+ * @param url - 需要格式化的URL字符串
+ * @returns 解码后的URL字符串
+ */
+export function formatUrlForDisplay(url: string): string {
+  // 只解码URL，不限制行数
+  return decodeUrl(url)
+}
+
+/**
+ * 获取适合HTML显示的URL（只处理编码）
+ * @param url - 原始URL（可以是字符串或URL对象）
+ * @returns 解码后的URL字符串
+ */
+export function getDisplayUrl(url: string | URL): string {
+  // 处理URL对象
+  const urlString = typeof url === 'string' ? url : url.href
+  // 只解码URL，不添加换行
+  return formatUrlForDisplay(urlString)
+}


### PR DESCRIPTION
此PR解决的是 Issue https://github.com/cworld1/astro-theme-pure/issues/135 中描述的问题。

> ### Description
> 在Copyright组件中，URL显示存在两个问题：
> 
> 1. **中文URL显示为ASCII编码**：包含中文的URL会显示为编码形式（如`%E4%B8%AD%E6%96%87`）而不是可读的中文字符
> 2. **URL过长影响布局**：对于上面的中文URL编码后基本都会超出组件范围，影响页面美观，对于英文URL过长也会出现该问题
> 
> <img alt="Image" width="987" height="176" src="https://private-user-images.githubusercontent.com/143786942/548565782-69fa1581-7782-4b1b-a6ab-838f0d38c7f4.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA4NjU1NDEsIm5iZiI6MTc3MDg2NTI0MSwicGF0aCI6Ii8xNDM3ODY5NDIvNTQ4NTY1NzgyLTY5ZmExNTgxLTc3ODItNGIxYi1hNmFiLTgzOGYwZDM4YzdmNC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMjEyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDIxMlQwMzAwNDFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01YjcwZGY1YzUyMmQ1OGI3OWIzNGY0MjFjMjkyNjU1N2QzZGRiNWY0YmE3NjQ0NjY4ZGYzMmIzZDg4NGRmNGIxJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.Uj1Mi1WHW3loyd_cJtJf9D68o64BitjmKDK06Xs6mog">
> ## 当前实现
> 在 `packages/pure/components/pages/Copyright.astro` 中：
> 
> <div class='text-sm'>{Astro.url}</div>
> 并没有做解码处理或者样式上的处理。

## 解决方案

### 1. 新增URL处理工具函数
创建 `packages/pure/utils/url.ts`，包含：
- `decodeUrl()`: 解码URL中的编码字符（处理中文等特殊字符）
- `formatUrlForDisplay()`: 格式化URL显示（只解码，不限制行数）
- `getDisplayUrl()`: 获取适合HTML显示的URL（支持字符串和URL对象）

### 2. 更新Copyright组件
修改 `packages/pure/components/pages/Copyright.astro`：
- 导入 `getDisplayUrl` 工具函数
- 使用 `set:html` 属性渲染解码后的URL
- 添加CSS样式控制：`w-3/4 break-all`（75%宽度，允许任意位置换行）

### 3. 更新工具函数导出
在 `packages/pure/utils/index.ts` 中导出新的URL工具函数。

## 效果图

### 对原来的短URL渲染效果无影响

<img width="605" height="189" alt="Snipaste_2026-02-12_10-56-22" src="https://github.com/user-attachments/assets/98e58885-983e-481b-a16a-6b435088c238" />

### 桌面端长URL效果

<img width="593" height="210" alt="Snipaste_2026-02-12_10-53-50" src="https://github.com/user-attachments/assets/fc4cce77-c45f-4b75-aa53-5ffc3d7bc6b4" />
<img width="658" height="250" alt="Snipaste_2026-02-12_10-55-03" src="https://github.com/user-attachments/assets/885ff920-4751-4b95-987d-97fa0546dae5" />

### 移动端长URL效果

<img width="281" height="609" alt="Snipaste_2026-02-12_10-55-41" src="https://github.com/user-attachments/assets/f8f3561f-1f0e-4814-82a3-c1a8c775f5aa" />
<img width="281" height="609" alt="Snipaste_2026-02-12_10-55-11" src="https://github.com/user-attachments/assets/8074e627-5a62-44f3-9f22-6ba2401233c9" />