### PR TITLE
fix: BackToTop z-index 99

### DIFF
--- a/packages/pure/components/pages/BackToTop.astro
+++ b/packages/pure/components/pages/BackToTop.astro
@@ -110,6 +110,7 @@ const { header: headerName, content: contentName, needPercent = true } = Astro.p
 
 <style>
   #action-buttons {
+    z-index: 99;
     transform: translateY(4rem);
     &.show {
       transform: translateY(0);


### PR DESCRIPTION
修复 bug: 在中等屏幕尺寸 TOC 侧边栏遮盖 BackToTop 按钮，导致 hover失效，无法点击
修复方法 BackToTop z-index  为 99
