### PR TITLE
feat(markdown): add markdown remote image render toggle

### DIFF
--- a/packages/pure/index.ts
+++ b/packages/pure/index.ts
@@ -12,6 +12,7 @@ import UnoCSS from '@unocss/astro'
 import rehypeExternalLinks from './plugins/rehype-external-links'
 import rehypeImageCaption from './plugins/rehype-image-caption'
 import rehypeTable from './plugins/rehype-table'
+import { remarkRemoteImagesToNativeImg } from './plugins/remark-remote-images'
 import { remarkAddZoomable, remarkReadingTime } from './plugins/remark-plugins'
 import { vitePluginUserConfig } from './plugins/virtual-user-config'
 import { UserConfigSchema, type UserInputConfig } from './types/user-config'
@@ -53,6 +54,8 @@ export default function AstroPureIntegration(opts: UserInputConfig): AstroIntegr
         // Add supported remark plugins based on user config.
         if (userConfig.integ.mediumZoom.enable)
           remarkPlugins.push([remarkAddZoomable, userConfig.integ.mediumZoom.options])
+        if (userConfig.integ.markdownImage.useNativeForRemote)
+          remarkPlugins.push(remarkRemoteImagesToNativeImg)
         remarkPlugins.push(remarkReadingTime)
 
         // Add supported rehype plugins based on user config.

--- a/packages/pure/plugins/remark-remote-images.ts
+++ b/packages/pure/plugins/remark-remote-images.ts
@@ -1,0 +1,94 @@
+import type { Definition, ImageReference, Root } from 'mdast'
+import type { Plugin } from 'unified'
+import { visit } from 'unist-util-visit'
+
+type HProperties = {
+  class?: unknown
+  className?: unknown
+  loading?: unknown
+  decoding?: unknown
+  fetchpriority?: unknown
+  referrerpolicy?: unknown
+}
+
+const escapeAttr = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+
+const joinClassName = (value: unknown): string | undefined => {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string').join(' ')
+  return undefined
+}
+
+const toRemoteUrl = (value: string): string | undefined => {
+  if (!URL.canParse(value)) return undefined
+  const url = new URL(value)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
+  return url.toString()
+}
+
+const toImgHtml = (
+  src: string,
+  alt: string | null | undefined,
+  title: string | null | undefined,
+  props: HProperties
+): string => {
+  const attrs: string[] = []
+
+  attrs.push(`src="${escapeAttr(src)}"`)
+  attrs.push(`alt="${escapeAttr(alt ?? '')}"`)
+
+  if (title) attrs.push(`title="${escapeAttr(title)}"`)
+
+  const className = joinClassName(props.className) ?? joinClassName(props.class)
+  if (className) attrs.push(`class="${escapeAttr(className)}"`)
+
+  const loading = typeof props.loading === 'string' ? props.loading : 'lazy'
+  const decoding = typeof props.decoding === 'string' ? props.decoding : 'async'
+  attrs.push(`loading="${escapeAttr(loading)}"`)
+  attrs.push(`decoding="${escapeAttr(decoding)}"`)
+
+  if (typeof props.fetchpriority === 'string')
+    attrs.push(`fetchpriority="${escapeAttr(props.fetchpriority)}"`)
+  if (typeof props.referrerpolicy === 'string')
+    attrs.push(`referrerpolicy="${escapeAttr(props.referrerpolicy)}"`)
+
+  return `<img ${attrs.join(' ')}>`
+}
+
+export const remarkRemoteImagesToNativeImg: Plugin<[], Root> =
+  () =>
+  (tree) => {
+    const definitionMap = new Map<string, Definition>()
+    visit(tree, 'definition', (node: Definition) => {
+      definitionMap.set(node.identifier, node)
+    })
+
+    visit(tree, 'image', (node, index, parent) => {
+      if (index === undefined || !parent) return
+      if (!toRemoteUrl(node.url)) return
+      parent.children[index] = {
+        type: 'html',
+        value: toImgHtml(node.url, node.alt, node.title, (node.data?.hProperties ?? {}) as HProperties)
+      }
+    })
+
+    visit(tree, 'imageReference', (node: ImageReference, index, parent) => {
+      if (index === undefined || !parent) return
+      const definition = definitionMap.get(node.identifier)
+      if (!definition || !toRemoteUrl(definition.url)) return
+      parent.children[index] = {
+        type: 'html',
+        value: toImgHtml(
+          definition.url,
+          node.alt,
+          definition.title,
+          (node.data?.hProperties ?? {}) as HProperties
+        )
+      }
+    })
+  }

--- a/packages/pure/types/integrations-config.ts
+++ b/packages/pure/types/integrations-config.ts
@@ -46,6 +46,17 @@ export const IntegrationConfigSchema = () =>
       options: z.record(z.string(), z.any()).default({ className: 'zoomable' })
     }),
 
+    /** Markdown image rendering strategy */
+    markdownImage: z
+      .object({
+        /**
+         * Render remote markdown images as native <img> tags to skip Astro's remote inferSize pipeline.
+         * Set to false to restore Astro's default remote image processing.
+         */
+        useNativeForRemote: z.boolean().default(true)
+      })
+      .default({ useNativeForRemote: true }),
+
     /** The Waline comment system */
     waline: z.object({
       /** Enable the Waline comment system. */

--- a/src/content/docs/integrations/others.mdx
+++ b/src/content/docs/integrations/others.mdx
@@ -63,6 +63,36 @@ import { MediumZoom } from 'astro-pure/advanced'
 </TabItem>
 </Tabs>
 
+## Markdown Remote Images
+
+When an article contains many remote images, Astro's default markdown image pipeline can be slow because it may probe remote image size (`inferSize`) during rendering.
+
+This theme provides a toggle to render remote markdown images as native `<img>` tags and skip that server-side probing path.
+
+```ts title="src/site.config.ts"
+export const integ: IntegrationUserConfig = {
+  // ...
+  markdownImage: {
+    // default: true
+    // true: render remote markdown images as native <img>
+    // false: restore Astro's default remote image pipeline
+    useNativeForRemote: false
+  }
+}
+```
+
+Keep writing markdown images as usual:
+
+```md
+![Alt text](https://example.com/image.png)
+```
+
+Notes:
+
+- `true` improves rendering responsiveness for image-heavy markdown pages.
+- `false` re-enables Astro image processing for remote markdown images.
+- Native `<img>` mode skips Astro optimization for those remote markdown images (such as automatic infer-size handling).
+
 
 ## `@playform/compress`
 
@@ -154,7 +184,7 @@ Rendering LaTeX in Astro.js enriches your markdown files with mathematical expre
 Common Pitfalls and Solutions:
 
 - CSS Styling Issues
-  
+
   Problem: LaTeX formulas might not render with the correct styles if the KaTeX CSS isn’t loaded.
 
   Solution: Confirm the KaTeX stylesheet link is correctly placed in the HTML head and is loading without issues. Check for network errors or restrictions that might prevent the CSS from loading.

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -161,6 +161,12 @@ export const integ: IntegrationUserConfig = {
       className: 'zoomable'
     }
   },
+  // [Markdown Image]
+  // Render remote Markdown images as native <img> tags to avoid Astro inferSize probing.
+  // Set to false to restore Astro's default remote image pipeline.
+  markdownImage: {
+    useNativeForRemote: false
+  },
   // Comment system
   waline: {
     enable: true,


### PR DESCRIPTION
你好，我最近发现了这个主题，我很喜欢这个风格！当前我也正在将内容迁移到这个博客上，在迁移过程中发现了一个问题，所以提交了这次PR，希望能对这个项目有所帮助。

**背景**
在包含大量远程图片的 Markdown 文章中，页面渲染会出现明显卡顿。通过将远程 Markdown 图片转换为原生 \<img> 的方式，绕过 Astro 远程 inferSize 探测链路，可显著改善加载体验。
同时将该行为做成可配置能力，可兼顾不同用户对“性能优先”与“图片优化优先”的选择。

**我查到的原因**

1. Astro 默认 Markdown 图片链路会将远程图片纳入 astro:assets 处理。
2. 对无显式宽高的远程图，常会触发 inferSize，引入额外网络探测。
3. 当单页远程图数量较多时，探测开销会累积，导致渲染阶段变慢。

**方案**

1. 新增配置项（带默认值）
   - 在 IntegrationConfigSchema 中新增 integ.markdownImage.useNativeForRemote，默认 false。
   - 位置：integrations-config.ts
2. 接入渲染开关逻辑
   - 在 astro-pure 集成中按配置决定是否启用 remarkRemoteImagesToNativeImg。
   - true：远程 Markdown 图片输出原生 \<img>，绕过 Astro 远程探测链路。
   - false：恢复 Astro 默认远程图片处理。
   - 位置：packages/pure/index.ts
3. 提供用户侧配置示例
   - 在站点配置中加入 markdownImage 示例，便于直接开关。
   - 位置：site.config.ts
4. 补充文档说明
   - 在集成文档新增 Markdown Remote Images 小节，包含用途、配置示例、行为说明与权衡。
   - 位置：src/content/docs/integrations/others.mdx

**验证**

1. npm run check：通过（0 errors / 0 warnings / 0 hints）
2. npm run build：通过（代码开关接入后完整构建成功）

**影响范围**

1. 影响 astro-pure 集成配置模型（新增 integ.markdownImage.useNativeForRemote）。
2. 影响 Markdown/MDX 正文中的远程图片渲染策略（由开关控制）。
3. 不影响本地图片、heroImage 前置图字段、以及显式使用 \<Image /> 的页面逻辑。
4. 增加文档说明，不影响运行时功能。
