### PR TITLE
chore: dockerize Astro site for local build and serving

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,90 @@
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+
+# Docker
+Dockerfile*
+docker-compose*
+.dockerignore
+compose.yml
+
+# Git
+.git
+.gitignore
+.github
+
+# Documentation
+README.md
+README-zh-CN.md
+CODE_OF_CONDUCT.md
+LICENSE
+
+# Node
+node_modules
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Astro
+dist/
+.astro/
+
+# Vercel
+.vercel/
+
+# Netlify
+.netlify/
+
+# Wrangler
+.wrangler/
+
+# VisualStudioCode
+.vscode
+.vscode/
+
+# Code workspace files
+*.code-workspace
+
+# Vim
+*.sw?
+*.swp
+[._]*.un~
+
+# VisualStudio
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+
+# TypeScript
+*.tsbuildinfo
+
+# Environment
+.env
+.env.production
+*.local
+
+# IDEs
+.idea/
+.editorconfig
+
+# Build / Coverage
+coverage*
+
+# Development
+Makefile
+helm-charts
+
+# Claude
+.claude/
+
+# Custom
+old_blog
+ignore.*
+/src/content/blog/test.*
+/test/
+bunfig.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM oven/bun:debian AS build
+
+WORKDIR /web
+
+COPY package.json .
+
+COPY bun.lock .
+
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+RUN bun astro telemetry disable && bun run build
+
+FROM oven/bun:debian AS dev
+
+WORKDIR /web
+
+COPY --from=build /web/node_modules ./node_modules
+
+COPY --from=build /web/dist /dist
+
+EXPOSE 4321

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -52,33 +52,96 @@
 
 在 NPM 上查看：[astro-theme-pure](https://www.npmjs.com/package/astro-pure)
 
-## 本地开发
+## 快速开始
 
-环境要求：
+### 环境要求
 
-- [Nodejs](https://nodejs.org/): 18.0.0+
+> [!WARNING]
+> Astro 6.0+ 要求 Node.js v22.12.0 或更高版本。Astro 不支持奇数版本的 Node.js，例如 v23。
 
-克隆存储库：
+你可以选择以下任一方式进行项目开发：
+
+- [Bun](https://bun.com/get) - 推荐用于本地开发
+- [Node.js](https://nodejs.org/zh-cn) - Bun 的替代方案
+- [Docker](https://docs.docker.com/get-started/get-docker) and [Docker Compose](https://docs.docker.com/compose/install) - 创建隔离的开发环境
+
+### 获取代码与配置
+
+1. 克隆仓库并进入目录：
+   ```shell
+   git clone https://github.com/cworld1/astro-theme-pure.git
+   cd astro-theme-pure
+   ```
+2. 配置站点：
+   - 编辑 `src/site.config.ts` 以个性化站点。
+
+#### 方式一：原生环境
+
+1. **安装依赖：**
+   ```shell
+   # 安装项目依赖
+   bun install
+   ```
+2. **启动开发服务器：**
+   ```shell
+   bun dev
+   # 或
+   pnpm dev
+   # 或
+   yarn run dev
+   # 或
+   npm run dev
+   ```
+   开发服务器默认运行在 <http://localhost:4321>。
+
+#### 方式二：Docker 隔离环境
+
+1. **构建并启动开发容器：**
+   ```shell
+   docker compose up --build
+   ```
+   首次运行会构建镜像，并在启动时将生产构建输出复制到本地 `./dist` 目录。开发服务器默认运行在 <http://localhost:4321>。
+2. **停止并移除容器：**
+   ```shell
+   docker compose down
+   ```
+
+### 创建新的博客文章
+
+完成任一开发环境的设置后，您可以创建一篇新的博客文章：
 
 ```shell
-git clone https://github.com/cworld1/astro-theme-pure.git
-cd astro-theme-pure
-```
-
-有用的命令：
-
-```shell
-# Install dependencies
-bun install
-# Start the dev server
-bun dev
-# Build the project
-bun run build
-# Preview (after the build)
-bun preview
-# Create a new post
+# 创建新文章
 bun pure new
 ```
+
+## 部署
+
+### 手动部署
+
+1. **构建生产站点到 `./dist` 目录：**
+   ```shell
+   bun run build
+   # 或
+   docker compose up --build
+   ```
+   构建完成后，生成的静态文件将位于 `./dist` 目录中，你可以将该目录部署到支持静态网站托管的平台。
+2. **本地预览构建结果（可选）：**
+   ```shell
+   # 预览前先完成构建
+   bun preview
+   ```
+
+### 静态托管平台
+
+你可以将你的博客部署到任意静态网站托管平台。
+
+- 参考官方 [Astro 部署指南](https://docs.astro.build/zh-cn/guides/deploy/) 了解具体的部署方式。
+- 根据所选择的部署平台，你可能需要修改项目中的 `astro.config.ts` 配置文件。
+
+| Vercel | Netlify |
+| :---: | :---: |
+| [![使用 Vercel 部署](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcworld1%2Fastro-theme-pure) | [![部署到 Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cworld1/astro-theme-pure) |
 
 ## 贡献
 

--- a/README.md
+++ b/README.md
@@ -54,31 +54,94 @@ See [astro-theme-pure](https://www.npmjs.com/package/astro-pure) on npm.
 
 ## Local development
 
-Environment requirements:
+### Environment requirements
 
-- [Nodejs](https://nodejs.org/): 18.0.0+
+> [!WARNING]
+> Astro 6.0+ requires Node.js 22.12.0 or newer. Odd-numbered Node.js versions such as 23 are not supported by Astro.
 
-Clone the repository:
+You can choose one of the following methods for project development:
+
+- [Bun](https://bun.com/get) - Recommended for local development
+- [Node.js](https://nodejs.org/) - Alternative to Bun
+- [Docker](https://docs.docker.com/get-started/get-docker) and [Docker Compose](https://docs.docker.com/compose/install) - Create an isolated development environment
+
+### Getting started
+
+1. **Clone the repository and enter the directory:**
+   ```shell
+   git clone https://github.com/cworld1/astro-theme-pure.git
+   cd astro-theme-pure
+   ```
+2. **Configure the site:**
+   - Edit `src/site.config.ts` to customize the site.
+
+#### Option 1: Native environment
+
+1. **Install dependencies:**
+   ```shell
+   # Install project dependencies
+   bun install
+   ```
+2. **Start the development server:**
+   ```shell
+   bun dev
+   # or
+   pnpm dev
+   # or
+   yarn run dev
+   # or
+   npm run dev
+   ```
+   The development server runs at http://localhost:4321 by default.
+
+#### Option 2: Docker isolated environment
+
+1. **Build and start the development container:**
+   ```shell
+   docker compose up --build
+   ```
+   The first run builds the image and when it starts, copies the production build output to the local `./dist` directory. The development server runs at http://localhost:4321 by default.
+2. **Stop and remove the container:**
+   ```shell
+   docker compose down
+   ```
+
+### Creating a new blog article
+
+After setting up either development environment, you can create a new blog article:
 
 ```shell
-git clone https://github.com/cworld1/astro-theme-pure.git
-cd astro-theme-pure
-```
-
-Useful commands:
-
-```shell
-# Install dependencies
-bun install
-# Start the dev server
-bun dev
-# Build the project
-bun run build
-# Preview (after the build)
-bun preview
 # Create a new post
 bun pure new
 ```
+
+## Deployment
+
+### Manual deployment
+
+1. **Build the production site into the `./dist` directory:**
+   ```shell
+   bun run build
+   # or
+   docker compose up --build
+   ```
+   Once the build is complete, the generated static files will be located in the `./dist` directory. You can deploy this directory to any platform that supports static site hosting.
+2. **Preview the production build locally (optional):**
+   ```shell
+   # preview (build before previewing)
+   bun preview
+   ```
+
+### Static hosting platforms
+
+You can deploy your blog to any static site hosting platform.
+
+- Refer to the official [Astro Deployment Guide](https://docs.astro.build/en/guides/deploy/) for specific deployment methods.
+- Depending on the deployment platform you choose, you may need to modify the `astro.config.ts` configuration file in the project.
+
+| Vercel | Netlify |
+| :---: | :---: |
+| [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcworld1%2Fastro-theme-pure) | [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cworld1/astro-theme-pure) |
 
 ## Contributions
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,19 @@
+# Local-testing convenience only, not used for deployment.
+# Run:   docker compose up --build
+# Visit: http://localhost:4321
+
+services:
+  astro:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "4321:4321"
+    volumes:
+      - .:/web
+      - /web/node_modules
+      - ./dist:/export
+    command: >
+      sh -c "find /export -mindepth 1 -print -delete &&
+        cp -rv /dist/. /export/ &&
+        exec bun run dev --host 0.0.0.0"

--- a/src/content/docs/setup/getting-started.mdx
+++ b/src/content/docs/setup/getting-started.mdx
@@ -104,9 +104,36 @@ yarn run dev
 npm run dev
 ```
 </TabItem>
+<TabItem label='docker'>
+```shell
+docker compose up --build
+```
+</TabItem>
 </Tabs>
 
 Next, please read the configuration notes first and continue configuring the theme.
+
+### Develop with Docker Compose
+
+The template also includes a `Dockerfile` and `compose.yml` for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
+
+Requirements:
+
+- Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.
+
+```shell
+docker compose up --build
+```
+
+The first run downloads the `oven/bun:debian` base image, which is about 82 MB compressed before project dependencies and build layers are added.
+
+After the container starts, open http://localhost:4321. The Compose service mounts your source files into the container, so Astro's dev server watches for changes and automatically rebuilds while you edit. On each `docker compose up --build` run, it also copies the generated `./dist` output from the image into your local `dist` directory.
+
+To stop the container, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove the stopped container afterwards, run:
+
+```shell
+docker compose down
+```
 
 ## Migrate to Astro
 
@@ -132,6 +159,8 @@ The theme file structure is as follows:
 - `uno.config.ts`: UnoCSS configuration file
 - `tsconfig.json`: Typescript configuration file
 - `package.json`: Package information
+- `Dockerfile`: Docker build setup for local development
+- `compose.yml`: Docker Compose configuration for local dev and preview
 
 ## Simple Setup
 


### PR DESCRIPTION
The Astro site can now be built and served locally using Docker, with file watching enabled to automatically rebuild when source files change.

To run locally:

1. Clone the repository.
2. Run `docker compose up --build`.
3. Visit `http://localhost:4321` to view the site.

Runs dependency installation and the Astro build in an isolated Docker container, reducing the potential impact of a supply-chain attack on the host. This setup is for local development only, not deployment.
