### PR TITLE
docs: fix star history chart link

### DIFF
--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -96,4 +96,4 @@ bun pure new
 
 本项目基于 Apache 2.0 许可证。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cworld1/astro-theme-pure&type=Date)](https://star-history.com/#cworld1/astro-theme-pure&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cworld1/astro-theme-pure&type=Date)](https://star-history.dera.page/#cworld1/astro-theme-pure&Date)

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Other third party references are on [Docs#Contributions](https://astro-pure.js.o
 
 This project is licensed under the Apache 2.0 License.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cworld1/astro-theme-pure&type=Date)](https://star-history.com/#cworld1/astro-theme-pure&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cworld1/astro-theme-pure&type=Date)](https://star-history.dera.page/#cworld1/astro-theme-pure&Date)


### PR DESCRIPTION
The star history chart in the README was broken because the original service relies on GitHub's stargazer API restrictions. This change points the chart to star-history.dera.page, which uses an alternative data source that needs no API token, restoring the chart for both the English and Chinese README.