### PR TITLE
bugfix: correct terms pages back link

### DIFF
--- a/src/pages/terms/copyright.md
+++ b/src/pages/terms/copyright.md
@@ -4,7 +4,7 @@ layout: '@/layouts/IndividualPage.astro'
 title: 'Copyright'
 description: 'Effective date: 2024-11-26'
 language: 'En'
-back: '/terms/list'
+back: '/terms'
 ---
 
 It may be recommended to generate policies from [PolicyMaker.io](https://policymaker.io).

--- a/src/pages/terms/disclaimer.md
+++ b/src/pages/terms/disclaimer.md
@@ -4,7 +4,7 @@ layout: '@/layouts/IndividualPage.astro'
 title: 'Disclaimer'
 description: 'Last updated: 2024-11-26'
 language: 'En'
-back: '/terms/list'
+back: '/terms'
 ---
 
 It may be recommended to generate policies from [PolicyMaker.io](https://policymaker.io).

--- a/src/pages/terms/privacy-policy.md
+++ b/src/pages/terms/privacy-policy.md
@@ -4,7 +4,7 @@ layout: '@/layouts/IndividualPage.astro'
 title: 'Privacy Policy'
 description: 'Effective date: 2024-11-26'
 language: 'En'
-back: '/terms/list'
+back: '/terms'
 ---
 
 It may be recommended to generate policies from [PolicyMaker.io](https://policymaker.io).

--- a/src/pages/terms/terms-and-conditions.md
+++ b/src/pages/terms/terms-and-conditions.md
@@ -4,7 +4,7 @@ layout: '@/layouts/IndividualPage.astro'
 title: 'Terms and Conditions'
 description: 'Last updated: 2024-11-26'
 language: 'En'
-back: '/terms/list'
+back: '/terms'
 ---
 
 It may be recommended to generate policies from [PolicyMaker.io](https://policymaker.io).


### PR DESCRIPTION
## Summary

Fix the Back button on the terms pages.

The pages currently use `/terms/list`, but this route does not exist and results in a 404 page. The terms list is provided by `src/pages/terms/index.astro`, whose route is `/terms`.

## Changes

Changed the `back` frontmatter value from `/terms/list` to `/terms` in:

- Privacy Policy
- Terms and Conditions
- Copyright
- Disclaimer

## Testing

- Confirmed that `/terms` is the existing terms list route.
- Confirmed that all four Back buttons now navigate to `/terms`.
- Ran `bun run build`.