### PR TITLE
fix(projects): preserve GitHub activity chart as SVG

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -34,6 +34,7 @@ const headings = [
   <p>
     <Image
       src='https://ghchart.rshah.org/659eb9/cworld1'
+      format='svg'
       alt='github activities'
       inferSize
       loading='lazy'


### PR DESCRIPTION
The GitHub activity chart is provided as an SVG, but using `<Image>` component without specifying the output format can cause the SVG to be rasterized. This causes text and other vector elements in the chart to appear blurry when zoomed.

### Changes:
- Explicitly set `format='svg'` for the GitHub activity chart in `src/pages/projects/index.astro`.
- Keep the chart as a vector image to preserve its visual quality when zoomed.

It appears when using the Vercel adapter, the generated URL instead uses Vercel's image optimization, so the SVG is preserved correctly, but not when the server adapter configuration is removed and Astro uses its default static output.