### PR TITLE
feat(docker): add profile-based local workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM oven/bun:debian AS build
 
 WORKDIR /web
 
-COPY package.json .
-
-COPY bun.lock .
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fontconfig && \
+    rm -rf /var/lib/apt/lists/*
+    
+COPY package.json bun.lock ./
 
 RUN bun install --frozen-lockfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,6 @@ RUN bun install --frozen-lockfile
 
 COPY . .
 
-RUN bun astro telemetry disable && bun run build
-
-FROM oven/bun:debian AS dev
-
-WORKDIR /web
-
-COPY --from=build /web/node_modules ./node_modules
-
-COPY --from=build /web/dist /dist
+ENV ASTRO_TELEMETRY_DISABLED=1
 
 EXPOSE 4321

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -96,11 +96,13 @@
 
 #### 方式二：Docker 隔离环境
 
+使用 Docker Compose 在 Bun 容器中运行 Astro 及其依赖，同时将项目源文件保留在宿主机上。
+
 1. **构建并启动开发容器：**
    ```shell
-   docker compose up --build
+   docker compose --profile dev up --build
    ```
-   首次运行会构建镜像，并在启动时将生产构建输出复制到本地 `./dist` 目录。开发服务器默认运行在 <http://localhost:4321>。
+   首次运行会构建镜像。启动时，会将项目源代码挂载到容器中，并将 node_modules 存储在 Docker 管理的卷中。开发服务器默认运行在 http://localhost:4321。
 2. **停止并移除容器：**
    ```shell
    docker compose down
@@ -113,6 +115,8 @@
 ```shell
 # 创建新文章
 bun pure new
+# 或
+docker compose --profile new run --rm new
 ```
 
 ## 部署
@@ -123,13 +127,15 @@ bun pure new
    ```shell
    bun run build
    # 或
-   docker compose up --build
+   docker compose --profile build up --build
    ```
    构建完成后，生成的静态文件将位于 `./dist` 目录中，你可以将该目录部署到支持静态网站托管的平台。
 2. **本地预览构建结果（可选）：**
    ```shell
    # 预览前先完成构建
    bun preview
+   # 或
+   docker compose --profile preview up --build
    ```
 
 ### 静态托管平台

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -64,7 +64,7 @@
 - [Bun](https://bun.com/get)
 - [Node.js](https://nodejs.org/zh-cn)
 
-对于使用容器化部署如 [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install)，请参考文档 [Docker Compose](https://astro-pure.js.org/docs/setup/using-docker-compose)
+对于使用容器化部署如 [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install)，请参考文档 [Docker Compose](https://astro-pure.js.org/docs/setup/using-docker-compose)。
 
 ### 获取代码与配置
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -64,7 +64,7 @@
 - [Bun](https://bun.com/get)
 - [Node.js](https://nodejs.org/zh-cn)
 
-对于使用容器化部署如 [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install)，请参考文档 [Deployment#Using Docker Compose](https://astro-pure.js.org/docs/setup/deployment#using-docker-compose)
+对于使用容器化部署如 [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install)，请参考文档 [Docker Compose](https://astro-pure.js.org/docs/setup/using-docker-compose)
 
 ### 获取代码与配置
 

--- a/README-zh-CN.md
+++ b/README-zh-CN.md
@@ -61,9 +61,10 @@
 
 你可以选择以下任一方式进行项目开发：
 
-- [Bun](https://bun.com/get) - 推荐用于本地开发
-- [Node.js](https://nodejs.org/zh-cn) - Bun 的替代方案
-- [Docker](https://docs.docker.com/get-started/get-docker) and [Docker Compose](https://docs.docker.com/compose/install) - 创建隔离的开发环境
+- [Bun](https://bun.com/get)
+- [Node.js](https://nodejs.org/zh-cn)
+
+对于使用容器化部署如 [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install)，请参考文档 [Deployment#Using Docker Compose](https://astro-pure.js.org/docs/setup/deployment#using-docker-compose)
 
 ### 获取代码与配置
 
@@ -72,17 +73,16 @@
    git clone https://github.com/cworld1/astro-theme-pure.git
    cd astro-theme-pure
    ```
-2. 配置站点：
-   - 编辑 `src/site.config.ts` 以个性化站点。
 
-#### 方式一：原生环境
+   编辑 `src/site.config.ts` 以个性化站点。
 
-1. **安装依赖：**
+2. 安装依赖：
    ```shell
    # 安装项目依赖
    bun install
    ```
-2. **启动开发服务器：**
+
+3. 启动开发服务器：
    ```shell
    bun dev
    # 或
@@ -92,51 +92,34 @@
    # 或
    npm run dev
    ```
+   
    开发服务器默认运行在 <http://localhost:4321>。
-
-#### 方式二：Docker 隔离环境
-
-使用 Docker Compose 在 Bun 容器中运行 Astro 及其依赖，同时将项目源文件保留在宿主机上。
-
-1. **构建并启动开发容器：**
-   ```shell
-   docker compose --profile dev up --build
-   ```
-   首次运行会构建镜像。启动时，会将项目源代码挂载到容器中，并将 node_modules 存储在 Docker 管理的卷中。开发服务器默认运行在 http://localhost:4321。
-2. **停止并移除容器：**
-   ```shell
-   docker compose down
-   ```
 
 ### 创建新的博客文章
 
 完成任一开发环境的设置后，您可以创建一篇新的博客文章：
 
 ```shell
-# 创建新文章
 bun pure new
-# 或
-docker compose --profile new run --rm new
 ```
 
 ## 部署
 
 ### 手动部署
 
-1. **构建生产站点到 `./dist` 目录：**
-   ```shell
-   bun run build
-   # 或
-   docker compose --profile build up --build
-   ```
-   构建完成后，生成的静态文件将位于 `./dist` 目录中，你可以将该目录部署到支持静态网站托管的平台。
-2. **本地预览构建结果（可选）：**
-   ```shell
-   # 预览前先完成构建
-   bun preview
-   # 或
-   docker compose --profile preview up --build
-   ```
+构建生产站点到 `./dist` 目录：
+
+```shell
+bun run build
+```
+
+构建完成后，生成的静态文件将位于 `./dist` 目录中，你可以将该目录部署到支持静态网站托管的平台。
+
+本地预览构建结果：
+
+```shell
+bun preview
+```
 
 ### 静态托管平台
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can choose one of the following methods for project development:
 - [Node.js](https://nodejs.org/)
 
 
-For deployment methods using container like [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer the documention [Deployment#Using Docker Compose](https://astro-pure.js.org/docs/setup/deployment#using-docker-compose).
+For deployment methods using container like [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer the documention [Using Docker Compose](https://astro-pure.js.org/docs/setup/using-docker-compose).
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -61,28 +61,28 @@ See [astro-theme-pure](https://www.npmjs.com/package/astro-pure) on npm.
 
 You can choose one of the following methods for project development:
 
-- [Bun](https://bun.com/get) - Recommended for local development
-- [Node.js](https://nodejs.org/) - Alternative to Bun
-- [Docker](https://docs.docker.com/get-started/get-docker) and [Docker Compose](https://docs.docker.com/compose/install) - Create an isolated development environment
+- [Bun](https://bun.com/get)
+- [Node.js](https://nodejs.org/)
+
+
+For deployment methods using container like [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer the documention [Deployment#Using Docker Compose](https://astro-pure.js.org/docs/setup/deployment#using-docker-compose).
 
 ### Getting started
 
-1. **Clone the repository and enter the directory:**
+1. Clone the repository and enter the directory:
    ```shell
    git clone https://github.com/cworld1/astro-theme-pure.git
    cd astro-theme-pure
    ```
-2. **Configure the site:**
-   - Edit `src/site.config.ts` to customize the site.
 
-#### Option 1: Native environment
+   Edit `src/site.config.ts` to customize the site.
 
-1. **Install dependencies:**
+2. Install dependencies:
    ```shell
-   # Install project dependencies
    bun install
    ```
-2. **Start the development server:**
+   
+3. Start the development server:
    ```shell
    bun dev
    # or
@@ -92,51 +92,34 @@ You can choose one of the following methods for project development:
    # or
    npm run dev
    ```
+   
    The development server runs at http://localhost:4321 by default.
-
-#### Option 2: Docker isolated environment
-
-Use Docker Compose to run Astro and its dependencies inside a Bun container while keeping your project source files on the host.
-
-1. **Build and start the development container:**
-   ```shell
-   docker compose --profile dev up --build
-   ```
-   The first run builds the image and when it starts, mounts the project source into the container and stores `node_modules` in a Docker-managed volume. The development server runs at http://localhost:4321 by default.
-2. **Stop and remove the container:**
-   ```shell
-   docker compose down
-   ```
 
 ### Creating a new blog article
 
 After setting up either development environment, you can create a new blog article:
 
 ```shell
-# Create a new post
 bun pure new
-# or
-docker compose --profile new run --rm new
 ```
 
 ## Deployment
 
 ### Manual deployment
 
-1. **Build the production site into the `./dist` directory:**
-   ```shell
-   bun run build
-   # or
-   docker compose --profile build up --build
-   ```
-   Once the build is complete, the generated static files will be located in the `./dist` directory. You can deploy this directory to any platform that supports static site hosting.
-2. **Preview the production build locally (optional):**
-   ```shell
-   # preview (build before previewing)
-   bun preview
-   # or
-   docker compose --profile preview up --build
-   ```
+Build the production site into the `./dist` directory:
+
+```shell
+bun run build
+```
+   
+Once the build is complete, the generated static files will be located in the `./dist` directory. You can deploy this directory to any platform that supports static site hosting.
+   
+Preview the production build locally:
+
+```shell
+bun preview
+```
 
 ### Static hosting platforms
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,13 @@ You can choose one of the following methods for project development:
 
 #### Option 2: Docker isolated environment
 
+Use Docker Compose to run Astro and its dependencies inside a Bun container while keeping your project source files on the host.
+
 1. **Build and start the development container:**
    ```shell
-   docker compose up --build
+   docker compose --profile dev up --build
    ```
-   The first run builds the image and when it starts, copies the production build output to the local `./dist` directory. The development server runs at http://localhost:4321 by default.
+   The first run builds the image and when it starts, mounts the project source into the container and stores `node_modules` in a Docker-managed volume. The development server runs at http://localhost:4321 by default.
 2. **Stop and remove the container:**
    ```shell
    docker compose down
@@ -113,6 +115,8 @@ After setting up either development environment, you can create a new blog artic
 ```shell
 # Create a new post
 bun pure new
+# or
+docker compose --profile new run --rm new
 ```
 
 ## Deployment
@@ -123,13 +127,15 @@ bun pure new
    ```shell
    bun run build
    # or
-   docker compose up --build
+   docker compose --profile build up --build
    ```
    Once the build is complete, the generated static files will be located in the `./dist` directory. You can deploy this directory to any platform that supports static site hosting.
 2. **Preview the production build locally (optional):**
    ```shell
    # preview (build before previewing)
    bun preview
+   # or
+   docker compose --profile preview up --build
    ```
 
 ### Static hosting platforms

--- a/compose.yml
+++ b/compose.yml
@@ -12,7 +12,7 @@
 # Start the Astro development server with source files mounted:
 #   docker compose --profile dev up --build
 #
-# Create a new article interactively:
+# Create a new article:
 #   docker compose --profile new run --rm new
 #
 # `--build` forces Docker to rebuild the image when the Dockerfile or build

--- a/compose.yml
+++ b/compose.yml
@@ -1,19 +1,98 @@
-# Local-testing convenience only, not used for deployment.
-# Run:   docker compose up --build
-# Visit: http://localhost:4321
+#
+# Local Docker workflows
+#
+# The services are profile-based so you can choose the workflow you need.
+#
+# Build the site and export the generated `dist/` to the host:
+#   docker compose --profile build up --build
+#
+# Preview the production build at http://localhost:4321:
+#   docker compose --profile preview up --build
+#
+# Start the Astro development server with source files mounted:
+#   docker compose --profile dev up --build
+#
+# Create a new article interactively:
+#   docker compose --profile new run --rm new
+#
+# `--build` forces Docker to rebuild the image when the Dockerfile or build
+# context changes. It is useful after changing dependencies or Docker config.
+#
+# The `preview` workflow runs the `build` service first and starts the
+# Astro preview server only after the build completes successfully.
+#
+# The `dev` workflow mounts the repository into the container, so source
+# changes are reflected immediately without rebuilding the image each time.
+#
+# The `new` workflow mounts `src/` and runs `astro-pure new` without
+# leaving a long-running container behind.
+#
+
+x-image: &default-image astro-pure:local
 
 services:
-  astro:
+  build:
+    profiles: [build, preview]
     build:
       context: .
-      target: dev
+      target: build
+    image: *default-image
+    pull_policy: never
+    working_dir: /web
+    volumes:
+      - dist:/web/dist
+      - ./dist:/export
+    command: >
+      sh -c "bun run build &&
+             find /export -mindepth 1 -print -delete &&
+             cp -rv /web/dist/. /export/"
+    restart: "no"
+
+  preview:
+    profiles: [preview]
+    build:
+      context: .
+      target: build
+    image: *default-image
+    pull_policy: never
+    working_dir: /web
+    depends_on:
+      build:
+        condition: service_completed_successfully
+    ports:
+      - "4321:4321"
+    volumes:
+      - dist:/web/dist
+    command: bun run preview --host 0.0.0.0
+
+  dev:
+    profiles: [dev]
+    build:
+      context: .
+      target: build
+    image: *default-image
+    pull_policy: never
+    working_dir: /web
     ports:
       - "4321:4321"
     volumes:
       - .:/web
-      - /web/node_modules
-      - ./dist:/export
-    command: >
-      sh -c "find /export -mindepth 1 -print -delete &&
-        cp -rv /dist/. /export/ &&
-        exec bun run dev --host 0.0.0.0"
+      - node_modules:/web/node_modules
+    command: bun run dev --host 0.0.0.0
+
+  new:
+    profiles: [new]
+    build:
+      context: .
+      target: build
+    image: *default-image
+    pull_policy: never
+    working_dir: /web
+    volumes:
+      - ./src/content:/web/src/content
+    command: bun run pure new
+    restart: "no"
+
+volumes:
+  dist:
+  node_modules:

--- a/src/content/docs/setup/configuration.md
+++ b/src/content/docs/setup/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuration'
 description: 'Configuration files'
-order: 4
+order: 5
 ---
 
 ## Theme Configuration

--- a/src/content/docs/setup/content.mdx
+++ b/src/content/docs/setup/content.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Authoring Content'
 description: 'Making your own content'
-order: 2
+order: 3
 ---
 
 import { Aside } from 'astro-pure/user'

--- a/src/content/docs/setup/deployment.mdx
+++ b/src/content/docs/setup/deployment.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deployment'
 description: 'Deploy your site to various platforms'
-order: 3
+order: 4
 ---
 
 import { Aside, Steps } from 'astro-pure/user'

--- a/src/content/docs/setup/getting-started.mdx
+++ b/src/content/docs/setup/getting-started.mdx
@@ -77,6 +77,10 @@ Then, you can start the Astro dev server and see a live preview of your project 
 
 ## Start the Dev Server
 
+<Aside type='tip'>
+For deployment methods using container like [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer the documention [Using Docker Compose](/docs/setup/using-docker-compose).
+</Aside>
+
 Go to your project directory:
 
 ```shell
@@ -104,41 +108,9 @@ yarn run dev
 npm run dev
 ```
 </TabItem>
-<TabItem label='docker'>
-```shell
-docker compose --profile dev up --build
-```
-</TabItem>
 </Tabs>
 
 Next, please read the configuration notes first and continue configuring the theme.
-
-### Develop with Docker Compose
-
-The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
-
-Requirements:
-
-- Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.
-
-The services are profile-based, so nothing starts unless you pick a profile with `--profile`:
-
-| Profile | Command | What it does |
-| --- | --- | --- |
-| `dev` | `docker compose --profile dev up --build` | Starts the Astro dev server at http://localhost:4321 with your source files bind-mounted, so edits are picked up immediately without rebuilding the image. |
-| `build` | `docker compose --profile build up --build` | Runs `astro build` inside the container and copies the output into your local `./dist` directory. |
-| `preview` | `docker compose --profile preview up --build` | Runs the `build` profile first, then serves the production build with `astro preview` at http://localhost:4321 once the build finishes. |
-| `new` | `docker compose --profile new run --rm new` | Runs `astro-pure new` to scaffold a new article, without leaving a container running afterwards. |
-
-<Aside type='tip'>
-`--build` tells Docker to rebuild the image, which is only needed after changing dependencies or the Docker config.
-</Aside>
-
-To stop the containers, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove stopped containers afterwards, run:
-
-```shell
-docker compose down
-```
 
 ## Migrate to Astro
 

--- a/src/content/docs/setup/getting-started.mdx
+++ b/src/content/docs/setup/getting-started.mdx
@@ -106,7 +106,7 @@ npm run dev
 </TabItem>
 <TabItem label='docker'>
 ```shell
-docker compose up --build
+docker compose --profile dev up --build
 ```
 </TabItem>
 </Tabs>
@@ -115,21 +115,26 @@ Next, please read the configuration notes first and continue configuring the the
 
 ### Develop with Docker Compose
 
-The template also includes a `Dockerfile` and `compose.yml` for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
+The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
 
 Requirements:
 
 - Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.
 
-```shell
-docker compose up --build
-```
+The services are profile-based, so nothing starts unless you pick a profile with `--profile`:
 
-The first run downloads the `oven/bun:debian` base image, which is about 82 MB compressed before project dependencies and build layers are added.
+| Profile | Command | What it does |
+| --- | --- | --- |
+| `dev` | `docker compose --profile dev up --build` | Starts the Astro dev server at http://localhost:4321 with your source files bind-mounted, so edits are picked up immediately without rebuilding the image. |
+| `build` | `docker compose --profile build up --build` | Runs `astro build` inside the container and copies the output into your local `./dist` directory. |
+| `preview` | `docker compose --profile preview up --build` | Runs the `build` profile first, then serves the production build with `astro preview` at http://localhost:4321 once the build finishes. |
+| `new` | `docker compose --profile new run --rm new` | Runs `astro-pure new` to scaffold a new article, without leaving a container running afterwards. |
 
-After the container starts, open http://localhost:4321. The Compose service mounts your source files into the container, so Astro's dev server watches for changes and automatically rebuilds while you edit. On each `docker compose up --build` run, it also copies the generated `./dist` output from the image into your local `dist` directory.
+<Aside type='tip'>
+`--build` tells Docker to rebuild the image, which is only needed after changing dependencies or the Docker config.
+</Aside>
 
-To stop the container, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove the stopped container afterwards, run:
+To stop the containers, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove stopped containers afterwards, run:
 
 ```shell
 docker compose down

--- a/src/content/docs/setup/getting-started.mdx
+++ b/src/content/docs/setup/getting-started.mdx
@@ -78,7 +78,7 @@ Then, you can start the Astro dev server and see a live preview of your project 
 ## Start the Dev Server
 
 <Aside type='tip'>
-For deployment methods using container like [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer the documention [Using Docker Compose](/docs/setup/using-docker-compose).
+For container-based workflows using [Docker](https://docs.docker.com/get-started/get-docker) & [Docker Compose](https://docs.docker.com/compose/install), please refer to the [Using Docker Compose](/docs/setup/using-docker-compose) documentation.
 </Aside>
 
 Go to your project directory:

--- a/src/content/docs/setup/using-docker-compose.mdx
+++ b/src/content/docs/setup/using-docker-compose.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Docker Compose'
+description: 'Develop & deploy theme using docker compose'
+order: 2
+---
+
+The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
+
+<Aside type='tip'>
+To build using Docker manually, please refer [Astro: Build your Astro site with Docker](https://docs.astro.build/en/recipes/docker/)
+</Aside>
+
+Requirements: Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.
+
+## Usage
+
+The services are profile-based, so nothing starts unless you pick a profile with `--profile`:
+
+| Profile | Command | What it does |
+| --- | --- | --- |
+| `dev` | `docker compose --profile dev up --build` | Starts the Astro dev server at http://localhost:4321 with your source files bind-mounted, so edits are picked up immediately without rebuilding the image. |
+| `build` | `docker compose --profile build up --build` | Runs `astro build` inside the container and copies the output into your local `./dist` directory. |
+| `preview` | `docker compose --profile preview up --build` | Runs the `build` profile first, then serves the production build with `astro preview` at http://localhost:4321 once the build finishes. |
+| `new` | `docker compose --profile new run --rm new` | Runs `astro-pure new` to scaffold a new article, without leaving a container running afterwards. |
+
+`--build` tells Docker to rebuild the image, which is only needed after changing dependencies or the Docker config.
+
+To stop the containers, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove stopped containers afterwards, run:
+
+```shell
+docker compose down
+```
+
+## Examples
+
+Develop locally:
+
+```shell
+docker compose --profile dev up --build
+```
+
+Create a new post:
+
+```shell
+docker compose --profile new run --rm new
+```
+
+Build site:
+
+```shell
+docker compose --profile build up --build
+```
+
+Preview:
+
+```shell
+docker compose --profile preview up --build
+```

--- a/src/content/docs/setup/using-docker-compose.mdx
+++ b/src/content/docs/setup/using-docker-compose.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Docker Compose'
-description: 'Develop & deploy theme using docker compose'
+description: 'Develop & deploy theme using Docker Compose'
 order: 2
 ---
 
@@ -9,7 +9,7 @@ import { Aside } from 'astro-pure/user'
 The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
 
 <Aside type='tip'>
-To build using Docker manually, please refer [Astro: Build your Astro site with Docker](https://docs.astro.build/en/recipes/docker/)
+To build using Docker manually, please refer to [Astro: Build your Astro site with Docker](https://docs.astro.build/en/recipes/docker/).
 </Aside>
 
 Requirements: Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.

--- a/src/content/docs/setup/using-docker-compose.mdx
+++ b/src/content/docs/setup/using-docker-compose.mdx
@@ -4,6 +4,8 @@ description: 'Develop & deploy theme using docker compose'
 order: 2
 ---
 
+import { Aside } from 'astro-pure/user'
+
 The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
 
 <Aside type='tip'>

--- a/src/content/docs/setup/using-docker-compose.mdx
+++ b/src/content/docs/setup/using-docker-compose.mdx
@@ -6,55 +6,187 @@ order: 2
 
 import { Aside } from 'astro-pure/user'
 
-The template includes a `Dockerfile` and `compose.yml` with profile-based services for local development. Use this when you want to build a development site with Astro running inside an isolated Bun container instead of installing dependencies directly on your host machine.
-
+Astro Theme Pure provides Docker Compose workflows for development, building, previewing and content creation in an isolated Bun container. This allows you to perform these workflows inside Docker without installing Bun or its dependencies or running the tooling directly on your host.
 <Aside type='tip'>
 To build using Docker manually, please refer to [Astro: Build your Astro site with Docker](https://docs.astro.build/en/recipes/docker/).
 </Aside>
 
-Requirements: Install [Docker](https://docs.docker.com/get-started/get-docker/) with Docker Compose support.
+## Requirements
 
-## Usage
+- [Docker Desktop](https://docs.docker.com/get-started/get-docker/) with [Docker Compose](https://docs.docker.com/compose/install) support.
 
-The services are profile-based, so nothing starts unless you pick a profile with `--profile`:
-
-| Profile | Command | What it does |
-| --- | --- | --- |
-| `dev` | `docker compose --profile dev up --build` | Starts the Astro dev server at http://localhost:4321 with your source files bind-mounted, so edits are picked up immediately without rebuilding the image. |
-| `build` | `docker compose --profile build up --build` | Runs `astro build` inside the container and copies the output into your local `./dist` directory. |
-| `preview` | `docker compose --profile preview up --build` | Runs the `build` profile first, then serves the production build with `astro preview` at http://localhost:4321 once the build finishes. |
-| `new` | `docker compose --profile new run --rm new` | Runs `astro-pure new` to scaffold a new article, without leaving a container running afterwards. |
-
-`--build` tells Docker to rebuild the image, which is only needed after changing dependencies or the Docker config.
-
-To stop the containers, press <kbd>Ctrl</kbd> + <kbd>C</kbd>. To remove stopped containers afterwards, run:
+Verify your installation:
 
 ```shell
-docker compose down
+docker --version
+docker compose version
 ```
 
-## Examples
+## How it works
 
-Develop locally:
+The included Docker environment uses:
 
-```shell
-docker compose --profile dev up --build
-```
+- **Bun** via the official `oven/bun:debian` image
+- A shared Docker image built from the repository `Dockerfile`
+- Compose profiles to run specific workflows
+- Named Docker volumes for build artifacts and dependencies
 
-Create a new post:
+The Docker image:
 
-```shell
-docker compose --profile new run --rm new
-```
+- Installs project dependencies with `bun install --frozen-lockfile`
+- Disables Astro telemetry
+- Exposes port `4321`
+- Uses `/web` as the working directory
 
-Build site:
+All services reuse the same image and only start when the corresponding profile is selected.
+
+## Available profiles
+
+Each workflow is exposed through a Docker Compose profile. Select the profile corresponding to the task you want to perform:
+
+| Profile | What it does |
+| --- | --- |
+| `build` | Runs `astro build` inside the container and copies the output into your local `./dist` directory. |
+| `dev` | Starts the Astro dev server at http://localhost:4321 with your source files bind-mounted, so edits are picked up immediately without rebuilding the image. |
+| `preview` |  Runs the `build` profile first, then serves the production build with `astro preview` at http://localhost:4321 once the build finishes. |
+| `new` | Runs `astro-pure new` to scaffold a new article, without leaving a container running afterwards. |
+
+## Building for production
+
+Generate a production build:
 
 ```shell
 docker compose --profile build up --build
 ```
 
-Preview:
+The build process:
+
+1. Runs `bun run build`
+2. Creates the Astro production output inside the container
+3. Copies the generated files into your local `./dist` directory
+
+After the build completes, the generated site is available in:
+
+```text
+./dist
+```
+
+The build container exits automatically when finished.
+
+## Rebuilding the Docker image
+
+The `--build` flag forces Docker Compose to rebuild the image before starting services.
+
+Use it when:
+
+- Updating project dependencies
+- Modifying `package.json`
+- Changing the `Dockerfile`
+- Switching to a branch with dependency changes
+
+Example:
+
+```shell
+docker compose --profile dev up --build
+```
+<Aside type='tip'>
+Running `--build` again does not necessarily rebuild every layer from scratch. Docker reuses cached layers when possible, so unchanged dependencies and other build steps can still be cached.
+</Aside>
+
+## Development
+
+Start the Astro development server:
+
+```shell
+docker compose --profile dev up --build
+```
+
+The site will be available at:
+
+```text
+http://localhost:4321
+```
+
+### Hot reloading
+
+Your project directory is mounted directly into the container:
+
+```yaml
+- .:/web
+```
+
+This means changes to source files are immediately visible inside the container, allowing Astro's development server to hot reload automatically.
+
+Project dependencies are stored in a dedicated Docker volume:
+
+```yaml
+- node_modules:/web/node_modules
+```
+
+This avoids conflicts between container-managed dependencies and any local environment.
+
+To stop the development server, press <kbd>Ctrl</kbd> + <kbd>C</kbd>.
+
+## Previewing a production build
+
+To build and serve the production output:
 
 ```shell
 docker compose --profile preview up --build
 ```
+
+The preview workflow:
+
+1. Executes the `build` service
+2. Shares the generated files through a Docker volume
+3. Starts Astro Preview
+
+The production preview is available at:
+
+```text
+http://localhost:4321
+```
+
+This is useful for verifying behavior closer to a production deployment than the development server.
+
+## Creating an article
+
+Astro Theme Pure provides a command for scaffolding new articles that can be run without installing dependencies locally.
+
+Create a new article:
+
+```shell
+docker compose --profile new run --rm new
+```
+
+This executes:
+
+```shell
+bun run pure new
+```
+
+The container mounts only the content directory:
+
+```yaml
+- ./src/content:/web/src/content
+```
+
+Any generated content is written directly into your project.
+
+The `--rm` flag automatically removes the temporary container after the command completes.
+
+## Cleaning up
+
+Stop containers and remove Compose resources:
+
+```shell
+docker compose down
+```
+
+Remove associated volumes as well:
+
+```shell
+docker compose down --volumes
+```
+
+This removes cached build output and installed dependencies stored in Docker volumes.


### PR DESCRIPTION
Added profile-based Docker Compose workflows, providing separate commands for development, production builds, local production previews and creating new articles.

The Docker image is also updated to provide fontconfig, fixing the Sharp image-processing error that occurs when Linux fontconfig configuration is unavailable.

## Usage

The recommended Docker commands are:
```sh
# Development
docker compose --profile dev up --build

# Production build
docker compose --profile build up --build

# Production preview
docker compose --profile preview up --build

# Create a new article
docker compose --profile new run --rm new
```
Using `--build` keeps the documented commands safe after changes to the `Dockerfile` or project dependencies while allowing Docker to reuse its build cache.